### PR TITLE
Add pygments for syntax highlighting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM debian
 
 RUN apt update && apt install --no-install-recommends --yes \
             make \
+            python-pygments \
             texlive \
             texlive-latex-extra \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
The minted package requires the `pygmentize` command:

>    ! Package minted Error: You must have `pygmentize' installed to
>    use this package.

This change adds python-pygments to the list of packages included in
this image.